### PR TITLE
Feature/token entropy pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,26 @@ This is based on the hypothesis that consumer-tuned models may still contain lat
 
 ## Current State
 
-This is very much a work in progress. The basic pipeline functions and can:
+This is very much a work in progress. The basic pipeline functions and will:
 
-- Generate multiple continuation "stems" from branching points
-- Create embeddings of stems using a sentence transformer model
-- Cluster embeddings using a clustering algorhythm (DBSCAN or Heirarchical currently)
-- Build an interactive tree visualization showing where semantic divergence is detected
-- Display the stem clustering of each node as a 3D PCA projection, along with the text of all stems in the cluster.
+- Recursively generate multiple continuation "stems" and nodes from an initial prompt
+- Prune stems based on abrupt jumps in token entropy
+- Create semantic embeddings of stems using a sentence transformer model
+- Group stem embeddings using a clustering algorhythm (DBSCAN or Heirarchical currently)
+- Select cluster representitives for continuation or branching
+- Build an interactive html visualization showing where semantic divergence is detected
+- Display the stem clustering of each node as a 3D PCA projection, along with the text of all stems in each cluster
 
 ## Limitations and TODOs
 
 - Only tested on GPT-2 models, which aren't really intelligent enough to function as an actual proof of concept. (larger models will need better memory management)
-- Clustering parameters need tuning for different domains.
-- Currently no quantitative metrics for "semantic divergence". Debatable as to whether or not sentence embeddings constitute a valid evaluation of meaning.
-- Visualization is bare-bones and could use more features/polish
-- Data output is sparse at the moment. Could use more comprehensive stats.
+- Inference, embedding, and clustering parameters need tuning for usable results in different prompts/domains
+- Currently no quantitative metrics for "semantic divergence". Debatable as to whether or not sentence embeddings constitute a valid evaluation of meaning
+- Depth-triggered branch clustering should be tested to validate semantic divergence is non-trival (and to reduce redundundant branching)
+- Visualization is rudimentary and could use more QoL features/polish
+- Data output is sparse at the moment. Could use more comprehensive stats
 - Limited testing on different model types and prompt categories
+- There are many places that could benefit from optimization and refactoring
 
 ## Possible Use Cases
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -3,6 +3,7 @@
 [model]
 # Model settings
 model_name = gpt2-xl
+;model_name = microsoft/Phi-3.5-mini-instruct
 device = cuda
 pad_token_mode = eos
 
@@ -11,37 +12,42 @@ pad_token_mode = eos
 
 seed = 42
 # max token depth of tree
-max_depth = 40
+max_depth = 48
 # length of each stem
-stem_length = 8
+stem_length = 12
 # min number of stems to generate at each node
-num_stems = 256
+num_stems = 56
 # max possible stems at a node
-max_stems_per_node = 2048
+max_stems_per_node = 512
 # number of stems to generate per forward pass
-batch_size = 64
+batch_size = 16
 
 # Token-level filtering
-temperature = 0.94
+temperature = 0.9
 top_k = 0
-top_p = 0.75
+top_p = 0.8
+
+# percentage range of tokens to search for entropy peak/prune location
+prune_range = .5
 
 [embeddings]
 # Embedding model for semantic analysis
 model_name = all-MiniLM-L6-v2
-batch_size = 128
+batch_size = 32
 
 [clustering]
 # Semantic clustering parameters
 cluster_type = hierarchical
 # percentage of total generated node stems required to form a cluster
-min_sample_ratio = 0.1
-# number of clusters required to trigger branching
+min_sample_ratio = 0.2
 
 [hi-clustering]
 # hierarchical clustering parameters
 linkage_criterion = complete
-cut_distance = 0.8
+# less distance creates more clusters with less semantic similarity
+cut_distance = 0.78
+# force returning the largest cluster even if it doesn't meet the min_sample_ratio
+# nodes with 0 clusters will simply terminate
 force_cluster = false
 
 [DBSCAN-clustering]

--- a/config/config.ini
+++ b/config/config.ini
@@ -15,20 +15,19 @@ seed = 42
 max_depth = 48
 # length of each stem
 stem_length = 12
+# range of stem tokens to search for pruning location: 1=full stem, .5=last half, etc.
+prune_range = .4
 # min number of stems to generate at each node
-num_stems = 56
+num_stems = 128
 # max possible stems at a node
 max_stems_per_node = 512
 # number of stems to generate per forward pass
 batch_size = 16
 
 # Token-level filtering
-temperature = 0.9
+temperature = 0.82
 top_k = 0
-top_p = 0.8
-
-# percentage range of tokens to search for entropy peak/prune location
-prune_range = .5
+top_p = 0.75
 
 [embeddings]
 # Embedding model for semantic analysis
@@ -39,13 +38,15 @@ batch_size = 32
 # Semantic clustering parameters
 cluster_type = hierarchical
 # percentage of total generated node stems required to form a cluster
-min_sample_ratio = 0.2
+# if a cluster doesn't contain min_sample_ratio of the total generated node stems,
+# it is discarded and its stems will be considered noise
+min_sample_ratio = 0.12
 
 [hi-clustering]
 # hierarchical clustering parameters
 linkage_criterion = complete
-# less distance creates more clusters with less semantic similarity
-cut_distance = 0.78
+# less distance creates more clusters with greater semantic similarity and fewer stems
+cut_distance = 0.65
 # force returning the largest cluster even if it doesn't meet the min_sample_ratio
 # nodes with 0 clusters will simply terminate
 force_cluster = false

--- a/divergent.py
+++ b/divergent.py
@@ -59,7 +59,7 @@ class DivergentGenerator:
             child = TreeNode(
                 token_id=rep_tokens[0] if hasattr(rep_tokens, '__getitem__') else 0,
                 token_text=child_text, probability=probability,
-                depth=parent_node.depth + stem_length)
+                depth=parent_node.depth + len(rep_tokens))  # Use actual length after pruning
             parent_node.add_child(child)
 
             new_sequence = branch_sequence + rep_tokens
@@ -149,7 +149,7 @@ class DivergentGenerator:
         Generate stems iteratively until clusters are found or max limit reached.
 
         Returns:
-            tuple of (stem_tokens, stem_texts, total_stems_generated)
+            tuple of (stem_tokens, stem_texts, clustering_result, total_stems_generated)
         """
         all_stem_tokens = []
         all_stem_texts = []
@@ -158,17 +158,19 @@ class DivergentGenerator:
         total_generated = 0
 
         while total_generated < max_total_stems:
-            # Generate current batch
-            stems = self.model.generate_stems(branch_sequence, current_batch_size, stem_length,
-                                            temperature=temperature, top_k=top_k, top_p=top_p)
+            # Generate current batch with entropy data
+            stems, entropies = self.model.generate_stems(branch_sequence, current_batch_size, stem_length,
+                                                       temperature=temperature, top_k=top_k, top_p=top_p)
 
-            # Extract tokens, texts, and embeddings
+            # Prune stems based on entropy peaks
+            pruned_stems = self._prune_stems_by_entropy(stems, entropies, stem_length)
 
-            batch_texts = [self.model.decode(tokens) for tokens in stems]
+            # Extract texts and embeddings
+            batch_texts = [self.model.decode(tokens) for tokens in pruned_stems]
             batch_embeddings = self.embedding_provider.get_embeddings(batch_texts)
 
             # Add to accumulated results
-            all_stem_tokens.extend(stems)
+            all_stem_tokens.extend(pruned_stems)
             all_stem_texts.extend(batch_texts)
 
             if all_stem_embeddings is None:
@@ -194,6 +196,37 @@ class DivergentGenerator:
             print(f"No clusters found with {total_generated} stems, generating {current_batch_size} more...")
 
         return all_stem_tokens, all_stem_texts, clustering_result, total_generated
+
+    def _prune_stems_by_entropy(self, stems: List[List[int]], entropies: List[List[float]],
+                               original_stem_length: int) -> List[List[int]]:
+        """Prune stems at token entropy peaks."""
+        prune_range = self.config.getfloat("generation", "prune_range")
+
+        pruned_stems = []
+        search_range = max(1, int(prune_range * original_stem_length))
+        min_length = original_stem_length - search_range
+
+        for stem, entropy_sequence in zip(stems, entropies):
+
+            # Look for entropy peak in the final search_range tokens
+            search_start = min_length
+            search_entropies = entropy_sequence[search_start:]
+
+            if not search_entropies:
+                # No search range, keep full stem
+                pruned_stems.append(stem)
+                continue
+
+            # TODO test using a moving average of entropy to filter out noise
+            # Find the index of maximum entropy in the search range
+            peak_idx_in_range = np.argmax(search_entropies)
+            peak_idx = search_start + peak_idx_in_range
+
+            # Prune stem at the entropy peak (inclusive)
+            pruned_stem = stem[:peak_idx + 1]
+            pruned_stems.append(pruned_stem)
+
+        return pruned_stems
 
     def _print_stems(self, stem_texts: List[str], branch_node: TreeNode, original_prompt: str):
         """Print stems for inspection."""

--- a/divergent.py
+++ b/divergent.py
@@ -212,18 +212,19 @@ class DivergentGenerator:
             search_start = min_length
             search_entropies = entropy_sequence[search_start:]
 
-            if not search_entropies:
+            if not search_entropies or len(search_entropies) <= 1:
                 # No search range, keep full stem
                 pruned_stems.append(stem)
                 continue
 
             # TODO test using a moving average of entropy to filter out noise
-            # Find the index of maximum entropy in the search range
-            peak_idx_in_range = np.argmax(search_entropies)
-            peak_idx = search_start + peak_idx_in_range
+            # Find largest entropy jump in the search range
+            entropy_diffs = np.diff(search_entropies)
+            max_jump_idx_in_range = np.argmax(entropy_diffs)
 
-            # Prune stem at the entropy peak (inclusive)
-            pruned_stem = stem[:peak_idx + 1]
+            # Prune stem before largest entropy jump in range
+            cut_idx = search_start + max_jump_idx_in_range + 1
+            pruned_stem = stem[:cut_idx]
             pruned_stems.append(pruned_stem)
 
         return pruned_stems

--- a/models/gpt_two.py
+++ b/models/gpt_two.py
@@ -3,6 +3,7 @@ from transformers import GPT2LMHeadModel, GPT2Tokenizer
 from models.model_interface import ModelInterface
 from config.config import get_config
 from typing import List, Tuple, Any
+import numpy as np
 
 
 class GPT2Interface(ModelInterface):
@@ -47,9 +48,9 @@ class GPT2Interface(ModelInterface):
         return self.tokenizer.decode([token_id])
 
     def generate_stems(self, input_ids: List[int], num_stems: int, stem_length: int,
-                      temperature: float = 1.0, top_k: int = 0, top_p: float = 1.0) -> List[Tuple[List[int], Any]]:
+                      temperature: float = 1.0, top_k: int = 0, top_p: float = 1.0) -> Tuple[List[List[int]], List[List[float]]]:
         """
-        Generate multiple continuation stems using HuggingFace's optimized generate.
+        Generate multiple continuation stems with per-token entropy data.
 
         Args:
             input_ids: List of input token IDs
@@ -60,46 +61,54 @@ class GPT2Interface(ModelInterface):
             top_p: Nucleus sampling threshold (1.0 = no filtering)
 
         Returns:
-            List of generated token IDs
+            Tuple of (generated_token_lists, entropy_lists)
         """
         config = get_config()
         stems = []
+        entropies = []
         batch_size = config.getint("generation", "batch_size")
 
         with torch.no_grad():
             for batch_start in range(0, num_stems, batch_size):
+                current_batch_size = min(batch_size, num_stems - batch_start)
 
                 # Convert input to tensor and create attention mask
                 input_tensor = torch.tensor([input_ids], dtype=torch.long, device=self.device)
                 attention_mask = torch.ones_like(input_tensor, dtype=torch.long, device=self.device)
 
-                # Generate batch of stems
+                # Generate batch of stems with scores
                 outputs = self.model.generate(
                     input_ids=input_tensor,
                     attention_mask=attention_mask,
                     max_new_tokens=stem_length,
                     min_new_tokens=stem_length,  # Force exact length
-                    num_return_sequences=batch_size,
+                    num_return_sequences=current_batch_size,
                     temperature=temperature if temperature > 0 else 1e-7,
                     top_k=top_k if top_k > 0 else None,
                     top_p=top_p if top_p < 1.0 else None,
                     do_sample=True,
                     pad_token_id=self.tokenizer.pad_token_id,
                     eos_token_id=self.tokenizer.eos_token_id,
-                    return_dict_in_generate=False,
+                    return_dict_in_generate=True,
+                    output_scores=True,
                     use_cache=True,
                 )
 
                 # Extract the generated portions
                 input_length = input_tensor.size(1)
-                generated_portions = outputs[:, input_length:]
+                generated_portions = outputs.sequences[:, input_length:]
 
-                # Convert to list and add to results
-                for i in range(batch_size):
+                # Calculate entropy from scores
+                batch_entropies = self._calculate_entropies(outputs.scores)
+
+                # Convert to lists and add to results
+                for i in range(current_batch_size):
                     generated_tokens = generated_portions[i].tolist()
+                    token_entropies = batch_entropies[i].tolist()
                     stems.append(generated_tokens)
+                    entropies.append(token_entropies)
 
-                # memory cleanup
+                # Memory cleanup
                 del outputs
                 del generated_portions
                 del input_tensor
@@ -109,4 +118,22 @@ class GPT2Interface(ModelInterface):
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
-        return stems
+        return stems, entropies
+
+    def _calculate_entropies(self, scores: Tuple[torch.Tensor]) -> torch.Tensor:
+        """Calculate per-token entropy from generation scores."""
+        # scores is a tuple of tensors, one for each generation step
+        # Each tensor has shape (batch_size, vocab_size)
+        entropies_per_step = []
+
+        for step_scores in scores:
+            # Convert logits to probabilities
+            probs = torch.softmax(step_scores, dim=-1)
+            # Calculate entropy: -sum(p * log(p))
+            entropy = -torch.sum(probs * torch.log(probs + 1e-8), dim=-1)
+            entropies_per_step.append(entropy)
+
+        # Stack to get shape (num_steps, batch_size)
+        entropies = torch.stack(entropies_per_step, dim=0)
+        # Transpose to get shape (batch_size, num_steps)
+        return entropies.transpose(0, 1)

--- a/models/mock_model.py
+++ b/models/mock_model.py
@@ -1,34 +1,35 @@
 import random
+import math
 from typing import List, Tuple, Any
 from models.model_interface import ModelInterface
 
 
 class MockTensor:
     """Simple tensor-like object to replace torch.Tensor."""
-    
+
     def __init__(self, data: List[int]):
         self.data = data
-    
+
     def tolist(self) -> List[int]:
         return self.data.copy()
-    
+
     def size(self, dim: int = None) -> int:
         if dim is None:
             return len(self.data)
         return len(self.data) if dim == 1 else 1
-    
+
     def unsqueeze(self, dim: int):
         return MockTensor([self.data])
-    
+
     def squeeze(self):
         return MockTensor(self.data)
-    
+
     def item(self) -> int:
         return self.data[0] if self.data else 0
-    
+
     def repeat(self, *sizes):
         return MockTensor(self.data)
-    
+
     def __getitem__(self, index):
         if isinstance(index, int):
             return self.data[index]
@@ -70,14 +71,14 @@ def mock_randn(*shape) -> List[float]:
 
 class MockModel(ModelInterface):
     """Torch-free mock model for testing."""
-    
+
     def __init__(self, mode: str = "semantic_clusters", vocab_size: int = 1000, seed: int = None):
         self.mode = mode
         self.vocab_size = vocab_size
-        
+
         if seed is not None:
             random.seed(seed)
-        
+
         self._build_vocabulary()
         self.custom_responses = {}
         if mode == "custom":
@@ -95,21 +96,21 @@ class MockModel(ModelInterface):
             "technical": ["system", "process", "algorithm", "function", "interface", "implementation"],
             "neutral": ["the", "and", "or", "but", "however", "therefore", "because", "while"]
         }
-        
+
         self.vocabulary = []
         self.token_to_group = {}
-        
+
         token_id = 0
         for group, words in self.semantic_groups.items():
             for word in words:
                 self.vocabulary.append(word)
                 self.token_to_group[token_id] = group
                 token_id += 1
-        
+
         while len(self.vocabulary) < self.vocab_size:
             self.vocabulary.append(f"token_{len(self.vocabulary)}")
             self.token_to_group[len(self.vocabulary) - 1] = "generic"
-    
+
     def _load_custom_responses(self):
         """Load predefined response patterns."""
         self.custom_responses = {
@@ -119,20 +120,20 @@ class MockModel(ModelInterface):
                 ["However,", "we", "might", "consider", "C"]
             ]
         }
-    
-    def encode(self, text: str) -> MockTensor:
-        """Encode text to mock token tensor."""
+
+    def encode(self, text: str) -> List[int]:
+        """Encode text to list of token IDs."""
         words = text.split()
         token_ids = []
-        
+
         for word in words:
             if word.lower() in self.vocabulary:
                 token_ids.append(self.vocabulary.index(word.lower()))
             else:
                 token_ids.append(random.randint(0, len(self.vocabulary) - 1))
-        
-        return MockTensor(token_ids)
-    
+
+        return token_ids
+
     def decode(self, token_ids: List[int]) -> str:
         """Decode token IDs to text."""
         words = []
@@ -141,83 +142,154 @@ class MockModel(ModelInterface):
                 words.append(self.vocabulary[token_id])
             else:
                 words.append(f"<unk_{token_id}>")
-        
+
         return " ".join(words)
-    
-    def generate_stems(self, input_ids: MockTensor, num_stems: int, stem_length: int,
-                      temperature: float = 1.0, top_k: int = 0, top_p: float = 1.0) -> List[Tuple[MockTensor, List[float]]]:
-        """Generate mock stems based on mode."""
+
+    def decode_single(self, token_id: int) -> str:
+        """Decode single token ID to text."""
+        if 0 <= token_id < len(self.vocabulary):
+            return self.vocabulary[token_id]
+        else:
+            return f"<unk_{token_id}>"
+
+    def generate_stems(self, input_ids: List[int], num_stems: int, stem_length: int,
+                      temperature: float = 1.0, top_k: int = 0, top_p: float = 1.0) -> Tuple[List[List[int]], List[List[float]]]:
+        """Generate mock stems with entropy calculation."""
         stems = []
-        
+        entropies = []
+
         for i in range(num_stems):
             if self.mode == "semantic_clusters":
-                tokens = self._generate_clustered_stem(i, num_stems, stem_length)
+                tokens, token_entropies = self._generate_clustered_stem(i, num_stems, stem_length, temperature)
             elif self.mode == "linear":
-                tokens = self._generate_linear_stem(stem_length)
+                tokens, token_entropies = self._generate_linear_stem(stem_length, temperature)
             elif self.mode == "custom":
-                tokens = self._generate_custom_stem(input_ids, stem_length)
+                tokens, token_entropies = self._generate_custom_stem(input_ids, stem_length, temperature)
             else:
-                tokens = self._generate_random_stem(stem_length)
+                tokens, token_entropies = self._generate_random_stem(stem_length, temperature)
 
-            stems.append((MockTensor(tokens)))
-        
-        return stems
+            stems.append(tokens)
+            entropies.append(token_entropies)
 
-    def _generate_clustered_stem(self, stem_index: int, total_stems: int, stem_length: int) -> List[int]:
-        """Generate stems designed to form clusters."""
+        return stems, entropies
+
+    def _calculate_mock_entropy(self, selected_token: int, context: str, temperature: float = 1.0) -> float:
+        """Calculate mock entropy based on how 'certain' the selection should be."""
+        # Base entropy varies by token type and context
+        base_entropy = 2.5  # Reasonable default for language models
+
+        # High-frequency words (like "the", "and") should have lower entropy
+        if selected_token < len(self.vocabulary):
+            token_word = self.vocabulary[selected_token]
+            if token_word in self.semantic_groups.get("neutral", []):
+                base_entropy = random.uniform(1.0, 2.0)  # More certain
+            elif any(token_word in group for group in self.semantic_groups.values()):
+                base_entropy = random.uniform(2.0, 3.5)  # Moderate certainty
+            else:
+                base_entropy = random.uniform(3.0, 5.0)  # Less certain
+
+        # Temperature affects entropy - higher temp means more uncertainty
+        temperature_factor = min(temperature, 2.0)  # Cap the effect
+        adjusted_entropy = base_entropy * (0.5 + 0.5 * temperature_factor)
+
+        # Add some random noise to make it feel more realistic
+        noise = random.uniform(-0.3, 0.3)
+        final_entropy = max(0.1, adjusted_entropy + noise)
+
+        return final_entropy
+
+    def _generate_clustered_stem(self, stem_index: int, total_stems: int, stem_length: int, temperature: float) -> Tuple[List[int], List[float]]:
+        """Generate stems designed to form clusters with corresponding entropies."""
         num_clusters = max(2, min(4, total_stems // 10))
         cluster_id = stem_index % num_clusters
-        
+
         group_names = list(self.semantic_groups.keys())
         target_group = group_names[cluster_id % len(group_names)]
-        
+
         tokens = []
-        for _ in range(stem_length):
+        token_entropies = []
+
+        for pos in range(stem_length):
             if random.random() < 0.7 and target_group in self.semantic_groups:
                 word = random.choice(self.semantic_groups[target_group])
                 token_id = self.vocabulary.index(word)
+                # Lower entropy for in-cluster tokens (more "certain")
+                entropy = self._calculate_mock_entropy(token_id, f"cluster_{cluster_id}_pos_{pos}", temperature * 0.8)
             else:
                 token_id = random.randint(0, len(self.vocabulary) - 1)
-            
+                # Higher entropy for random tokens
+                entropy = self._calculate_mock_entropy(token_id, f"random_pos_{pos}", temperature * 1.2)
+
             tokens.append(token_id)
-        
-        return tokens
-    
-    def _generate_linear_stem(self, stem_length: int) -> List[int]:
-        """Generate similar stems for no-branching scenario."""
+            token_entropies.append(entropy)
+
+        return tokens, token_entropies
+
+    def _generate_linear_stem(self, stem_length: int, temperature: float) -> Tuple[List[int], List[float]]:
+        """Generate similar stems for no-branching scenario with low entropy."""
         neutral_words = self.semantic_groups["neutral"]
         tokens = []
-        
+        token_entropies = []
+
         for i in range(stem_length):
             if i == 0 and random.random() < 0.3:
                 word = random.choice(neutral_words)
             else:
-                word = neutral_words[0]
-            
+                word = neutral_words[0]  # Very predictable
+
             token_id = self.vocabulary.index(word)
+            # Low entropy for predictable sequences
+            entropy = self._calculate_mock_entropy(token_id, f"linear_pos_{i}", temperature * 0.5)
+
             tokens.append(token_id)
-        
-        return tokens
-    
-    def _generate_custom_stem(self, input_ids: MockTensor, stem_length: int) -> List[int]:
-        """Generate from predefined patterns."""
+            token_entropies.append(entropy)
+
+        return tokens, token_entropies
+
+    def _generate_custom_stem(self, input_ids: List[int], stem_length: int, temperature: float) -> Tuple[List[int], List[float]]:
+        """Generate from predefined patterns with contextual entropy."""
+        tokens = []
+        token_entropies = []
+
         if "test_prompt" in self.custom_responses:
             responses = self.custom_responses["test_prompt"]
             response = random.choice(responses)
-            tokens = []
-            for word in response[:stem_length]:
+
+            for i, word in enumerate(response[:stem_length]):
                 if word.lower() in self.vocabulary:
-                    tokens.append(self.vocabulary.index(word.lower()))
+                    token_id = self.vocabulary.index(word.lower())
                 else:
-                    tokens.append(random.randint(0, len(self.vocabulary) - 1))
-        else:
-            tokens = [random.randint(0, len(self.vocabulary) - 1) for _ in range(stem_length)]
-        
-        return tokens
-    
-    def _generate_random_stem(self, stem_length: int) -> List[int]:
-        """Generate random token sequences."""
-        return [random.randint(0, len(self.vocabulary) - 1) for _ in range(stem_length)]
+                    token_id = random.randint(0, len(self.vocabulary) - 1)
+
+                # First tokens in custom responses tend to be more certain
+                position_factor = 0.8 if i < 2 else 1.0
+                entropy = self._calculate_mock_entropy(token_id, f"custom_pos_{i}", temperature * position_factor)
+
+                tokens.append(token_id)
+                token_entropies.append(entropy)
+
+        # Fill remaining positions if needed
+        while len(tokens) < stem_length:
+            token_id = random.randint(0, len(self.vocabulary) - 1)
+            entropy = self._calculate_mock_entropy(token_id, f"custom_fill_{len(tokens)}", temperature)
+            tokens.append(token_id)
+            token_entropies.append(entropy)
+
+        return tokens, token_entropies
+
+    def _generate_random_stem(self, stem_length: int, temperature: float) -> Tuple[List[int], List[float]]:
+        """Generate random token sequences with high entropy."""
+        tokens = []
+        token_entropies = []
+
+        for i in range(stem_length):
+            token_id = random.randint(0, len(self.vocabulary) - 1)
+            # Random generation should have higher entropy
+            entropy = self._calculate_mock_entropy(token_id, f"random_pos_{i}", temperature * 1.3)
+            tokens.append(token_id)
+            token_entropies.append(entropy)
+
+        return tokens, token_entropies
     
     def get_mode_info(self) -> str:
         """Get current mode description."""


### PR DESCRIPTION
Adds configurable token pruning for dynamic stem length based on entropy

- A configurable range of tokens in each generated stem is searched for the greatest jump in entropy between consecutive tokens. Tokens after the jump are pruned, so that subsequent rounds of continuation will generally begin with higher entropy tokens.
- The intention is to ensure that nodes have a tendency to appear at semantic "faults" or transitions between discrete ideas, so that they're more easily clustered into semantically consistent groups.